### PR TITLE
Use alternate way to install with openssl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ This is a brew tap for installing older versions of Python. Currently this tap h
 Prerequisites
 -------------
 
-The formula `openssl` will need to be installed and linked
+The formula `openssl` will need to be installed for the `ssl` module to work
 
     $ brew install openssl
-    $ brew link --force openssl
 
 How to Use
 ----------

--- a/python26.rb
+++ b/python26.rb
@@ -6,7 +6,9 @@ class Python26 < Formula
   sha256 "7277b1285d8a82f374ef6ebaac85b003266f7939b3f2a24a3af52f9523ac94db"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    cflags = "CFLAGS=-I/usr/local/opt/openssl/include"
+    ldflags = "LDFLAGS=-L/usr/local/opt/openssl/lib"
+    system "./configure", "--prefix=#{prefix}", cflags, ldflags
     system "make"
     system "make install"
   end

--- a/python31.rb
+++ b/python31.rb
@@ -6,7 +6,9 @@ class Python31 < Formula
   sha256 "d12dae6d06f52ef6bf1271db4d5b4d14b5dd39813e324314e72b648ef1bc0103"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    cflags = "CFLAGS=-I/usr/local/opt/openssl/include"
+    ldflags = "LDFLAGS=-L/usr/local/opt/openssl/lib"
+    system "./configure", "--prefix=#{prefix}", cflags, ldflags
     system "make"
     system "make install"
   end

--- a/python32.rb
+++ b/python32.rb
@@ -6,7 +6,9 @@ class Python32 < Formula
   sha256 "fc1e41296e29d476f696303acae293ae7a2310f0f9d0d637905e722a3f16163e"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    cflags = "CFLAGS=-I/usr/local/opt/openssl/include"
+    ldflags = "LDFLAGS=-L/usr/local/opt/openssl/lib"
+    system "./configure", "--prefix=#{prefix}", cflags, ldflags
     system "make"
     system "make install"
   end

--- a/python33.rb
+++ b/python33.rb
@@ -6,7 +6,9 @@ class Python33 < Formula
   sha256 "0a58ad1f1def4ecc90b18b0c410a3a0e1a48cf7692c75d1f83d0af080e5d2034"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    cflags = "CFLAGS=-I/usr/local/opt/openssl/include"
+    ldflags = "LDFLAGS=-L/usr/local/opt/openssl/lib"
+    system "./configure", "--prefix=#{prefix}", cflags, ldflags
     system "make"
     system "make install"
   end

--- a/python34.rb
+++ b/python34.rb
@@ -6,7 +6,9 @@ class Python34 < Formula
   sha256 "bc93e944025816ec360712b4c42d8d5f729eaed2b26585e9bc8844f93f0c382e"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    cflags = "CFLAGS=-I/usr/local/opt/openssl/include"
+    ldflags = "LDFLAGS=-L/usr/local/opt/openssl/lib"
+    system "./configure", "--prefix=#{prefix}", cflags, ldflags
     system "make"
     system "make install"
   end


### PR DESCRIPTION
This fixes #3 by adding the correct compile parameters to install python with the correct openssl version.